### PR TITLE
[bug #163038938]Rearrange meetup cards to use grid and reduce meetup …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+coverage
+.coveralls.yml
+.nyc_output

--- a/UI/assets/css/custom.css
+++ b/UI/assets/css/custom.css
@@ -7,6 +7,7 @@ body{
 }
 *{
   margin: 0;
+  box-sizing: border-box;
 }
 a{
   text-decoration: none;
@@ -17,6 +18,12 @@ a{
   font-weight: bold;
 }
 
+/*  */
+.flex-row {
+
+}
+
+/*  */
 
 /*  */
 .btn{

--- a/UI/assets/css/meetup.css
+++ b/UI/assets/css/meetup.css
@@ -55,6 +55,136 @@
 }
 
 
+/*  */
+.products-list{
+  padding: 0 0%;
+
+}
+.products-list-main-container{
+  width: 100%;
+  display: flex;
+  flex-flow :row wrap;
+  padding: 0% 0%;
+  /* background: green */
+}
+.products-list-main-container div{
+  -webkit-flex: 1;  /* Safari 6.1+ */
+  -ms-flex: 1;  /* IE 10 */
+  flex: 1;
+}
+.products-list-main-container > .product-card {
+  background-color: #ffffff;
+  /* box-shadow:  1px 2px 4px #c4c4c4; */
+  /* box-shadow:0px 2px 2px rgba(0, 0, 0, 0.25); */
+  padding: 5px;
+  min-width: 325px;
+  width: 275px;
+  max-width: 325px;
+  height: 320px;
+  margin: 35px!important;
+  border-radius: 3px;
+  /* margin-bottom: 0!important; */
+}
+.products-list-main-container > .product-card:hover {
+  box-shadow: 0px 0px 2px 2px rgba(0, 0, 0, 0.25);
+  /* box-shadow:0px 2px 2px red; */
+}
+.products-list-main-container > .product-card:nth-child(3n+1) {
+  /* margin-left: 0px!important; */
+}
+.products-list-main-container .product-card .card-image-top{
+  height: 70%;
+  /* background: red; */
+}
+.products-list-main-container .product-card .product-image{
+  width: 100%;
+  height: 100%;
+}
+.full-image{
+  width: 90%;
+  height: 300px;
+  margin-top: 5%!important
+}
+.image-caption{
+  text-align: center;
+}
+.table-product-image{
+  width: 125px;
+  height:75px;
+}
+.product-card .product-card-details{
+  padding: 5px;
+}
+.product-card .product-card-details .d-flex{
+  margin-top: 10px;
+}
+/*  */
+.product-card .product-card-details .add-product-btn{
+  width: 100%;
+  height: 30px;
+  background-color: #3380FF;
+  border:1px solid #3380FF;
+  color: #ffffff;
+  font-size: 16px;
+  line-height: 20px;
+  font-family: 'Ubuntu', sans-serif;
+  cursor: pointer;
+  display: flex;
+  box-shadow: 0px 2px 6px #c4c4c4;
+  justify-content: center;
+}
+.product-card .product-card-details .add-product-btn:hover{
+  background-color: #021FA0;
+  border:1px solid #021FA0;
+}
+.product-card .product-card-details .add-product-btn .fas{
+  padding-top: 3px!important;
+  margin-right: 5px!important;
+}
+/*  */
+/*  */
+.product-card .product-card-details .remove-product-btn{
+  width: 100%;
+  height: 30px;
+  background-color: #FF0000;
+  border:1px solid #FF0000;
+  color: #ffffff;
+  font-size: 16px;
+  line-height: 20px;
+  font-family: 'Ubuntu', sans-serif;
+  cursor: pointer;
+  display: flex;
+  box-shadow: 0px 2px 6px #c4c4c4;
+  justify-content: center;
+}
+.product-card .product-card-details .remove-product-btn:hover{
+  background-color: #990000;
+  border:1px solid #990000;
+}
+.product-card .product-card-details .remove-product-btn .fas{
+  padding-top: 3px!important;
+  margin-right: 5px!important;
+}
+/*  */
+.product-card .product-card-details .amount{
+  margin: 10px 0px !important;
+}
+.product-card .product-card-details .total{
+  margin: 15px 0px !important;
+
+}
+
+.products-list-main-container .product-card-details .product-quantity{
+  margin: 10px 0px!important;
+}
+
+
+
+
+
+/*  */
+
+
 /* Single meetup */
 .single-meetup-div{
   margin-top: 20px;

--- a/UI/meetups.html
+++ b/UI/meetups.html
@@ -36,84 +36,123 @@
         <div class="table-div">
           <div class="meetups-title-div">
             <p>All Meetups</p>
-            <p>Click on a card to view full details</p>
           </div>
-          <a href="single-meetup.html">
-            <div class="meetup-div">
-              <div class="d-block w-100">
-                <p class="f-14 text-grey time-posted">Posted : 7 hours ago</p>
-                <div class="main-content w-100">
-                  <!-- <i class="fas fa-image text-grey f-100"></i> -->
-                  <div class="image-div">
-                    <img src="assets/images/placeholder.png" alt="Meetup Image" class="meetup-image">
+          <div class="products-list row d-flex justify-content-center">
+            <div class="products-list-main-container">
+              <div class="product-card">
+                <a href="single-meetup.html">
+                  <div class="card-image-top">
+                    <img src="assets/images/placeholder.png" alt="empty cart" class="product-image">
                   </div>
-                  <div class="details w-100">
-                    <div class=" w-100 top">
-                      <div class="d-block">
-                        <p class="f-24">Making The Web Accessible For Everyone</p>
-                        <p>DevFestSS Uyo</p>
-                      </div>
-                      <div class="d-block right ">
-                        <p class="text-blue "> <span class="sm-hide">Date:</span> 12/12/12</p>
-                        <p class="d-flex"> <span class="sm-hide">Location:</span> Plot 3, lane E, 3rd Avenue, Eliminigwe Estate phase II, Elelenwo, Port Harcourt, Rivers State, Nigeria</p>
-                      </div>
-                    </div>
-                    <div class="d-flex tags ">
-                      <div class=" d-flex">
-                        <div class="tag tech">
-                          tech
-                        </div>
-                        <div class="tag health">
-                          health
-                        </div>
-                      </div>
-                      <div class="questions">
-                        <p class="text-red">Questions: 22</p>
-                      </div>
+                  <div class="product-card-details">
+                    <p class="f-20 "> <b>Making The Web Accessible For Everyone</b> </p>
+                    <div class="d-flex justify-content-between mt-1">
+                      <small class="f-12"><i>DevFestSS Uyo</i></small>
+                      <p class="text-blue">12/12/12</p>
                     </div>
                   </div>
-                </div>
+                </a>
+              </div>
+              <div class="product-card">
+                <a href="single-meetup.html">
+                  <div class="card-image-top">
+                    <img src="assets/images/placeholder.png" alt="empty cart" class="product-image">
+                  </div>
+                  <div class="product-card-details">
+                    <p class="f-20 "> <b>Making The Web Accessible For Everyone</b> </p>
+                    <div class="d-flex justify-content-between mt-1">
+                      <small class="f-12"><i>DevFestSS Uyo</i></small>
+                      <p class="text-blue">12/12/12</p>
+                    </div>
+                  </div>
+                </a>
+              </div>
+              <div class="product-card">
+                <a href="single-meetup.html">
+                  <div class="card-image-top">
+                    <img src="assets/images/placeholder.png" alt="empty cart" class="product-image">
+                  </div>
+                  <div class="product-card-details">
+                    <p class="f-20 "> <b>Making The Web Accessible For Everyone</b> </p>
+                    <div class="d-flex justify-content-between mt-1">
+                      <small class="f-12"><i>DevFestSS Uyo</i></small>
+                      <p class="text-blue">12/12/12</p>
+                    </div>
+                  </div>
+                </a>
+              </div>
+              <div class="product-card">
+                <a href="single-meetup.html">
+                  <div class="card-image-top">
+                    <img src="assets/images/placeholder.png" alt="empty cart" class="product-image">
+                  </div>
+                  <div class="product-card-details">
+                    <p class="f-20 "> <b>Making The Web Accessible For Everyone</b> </p>
+                    <div class="d-flex justify-content-between mt-1">
+                      <small class="f-12"><i>DevFestSS Uyo</i></small>
+                      <p class="text-blue">12/12/12</p>
+                    </div>
+                  </div>
+                </a>
+              </div>
+              <div class="product-card">
+                <a href="single-meetup.html">
+                  <div class="card-image-top">
+                    <img src="assets/images/placeholder.png" alt="empty cart" class="product-image">
+                  </div>
+                  <div class="product-card-details">
+                    <p class="f-20 "> <b>Making The Web Accessible For Everyone</b> </p>
+                    <div class="d-flex justify-content-between mt-1">
+                      <small class="f-12"><i>DevFestSS Uyo</i></small>
+                      <p class="text-blue">12/12/12</p>
+                    </div>
+                  </div>
+                </a>
+              </div>
+              <div class="product-card">
+                <a href="single-meetup.html">
+                  <div class="card-image-top">
+                    <img src="assets/images/placeholder.png" alt="empty cart" class="product-image">
+                  </div>
+                  <div class="product-card-details">
+                    <p class="f-20 "> <b>Making The Web Accessible For Everyone</b> </p>
+                    <div class="d-flex justify-content-between mt-1">
+                      <small class="f-12"><i>DevFestSS Uyo</i></small>
+                      <p class="text-blue">12/12/12</p>
+                    </div>
+                  </div>
+                </a>
+              </div>
+              <div class="product-card">
+                <a href="single-meetup.html">
+                  <div class="card-image-top">
+                    <img src="assets/images/placeholder.png" alt="empty cart" class="product-image">
+                  </div>
+                  <div class="product-card-details">
+                    <p class="f-20 "> <b>Making The Web Accessible For Everyone</b> </p>
+                    <div class="d-flex justify-content-between mt-1">
+                      <small class="f-12"><i>DevFestSS Uyo</i></small>
+                      <p class="text-blue">12/12/12</p>
+                    </div>
+                  </div>
+                </a>
+              </div>
+              <div class="product-card">
+                <a href="single-meetup.html">
+                  <div class="card-image-top">
+                    <img src="assets/images/placeholder.png" alt="empty cart" class="product-image">
+                  </div>
+                  <div class="product-card-details">
+                    <p class="f-20 "> <b>Making The Web Accessible For Everyone</b> </p>
+                    <div class="d-flex justify-content-between mt-1">
+                      <small class="f-12"><i>DevFestSS Uyo</i></small>
+                      <p class="text-blue">12/12/12</p>
+                    </div>
+                  </div>
+                </a>
               </div>
             </div>
-          </a>
-          <a href="single-meetup.html">
-            <div class="meetup-div">
-              <div class="d-block w-100">
-                <p class="f-14 text-grey time-posted">Posted : 7 hours ago</p>
-                <div class="main-content w-100">
-                  <!-- <i class="fas fa-image text-grey f-100"></i> -->
-                  <div class="image-div">
-                    <img src="assets/images/placeholder.png" alt="Meetup Image" class="meetup-image">
-                  </div>
-                  <div class="details w-100">
-                    <div class=" w-100 top">
-                      <div class="d-block">
-                        <p class="f-24">Making The Web Accessible For Everyone</p>
-                        <p>DevFestSS Uyo</p>
-                      </div>
-                      <div class="d-block right ">
-                        <p class="text-blue "> <span class="sm-hide">Date:</span> 12/12/12</p>
-                        <p class="d-flex"> <span class="sm-hide">Location:</span> Plot 3, lane E, 3rd Avenue, Eliminigwe Estate phase II, Elelenwo, Port Harcourt, Rivers State, Nigeria</p>
-                      </div>
-                    </div>
-                    <div class="d-flex tags ">
-                      <div class=" d-flex">
-                        <div class="tag tech">
-                          tech
-                        </div>
-                        <div class="tag health">
-                          health
-                        </div>
-                      </div>
-                      <div class="questions">
-                        <p class="text-red">Questions: 22</p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </a>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
#### What does this PR do?
This PR:
* Rearranges the meetups cards into a grid of 3
* Removes the text "click here to view full details from the page"
* Remove extra details about the meetup from the card

#### Description of Task to be completed?
* Move location, tags and number of questions to single meetup page
* Remove time of meetup creation totally
* Remove the text that says "click card to view full details"
* Arrange the meetup cards in grids of 4 or 3

#### How should this be manually tested?
visit https://nedyudombat.github.io/Questioner/UI/meetups.html

#### Any background context you want to provide?
No

#### What are the relevant pivotal tracker stories?(if applicable)
 #163038938