### PR TITLE
[feat #163451769]Remove wrong link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,6 @@ Questioner is a web application that helps event organizers gather and prioritiz
 * [nyc](https://github.com/istanbuljs/nyc) - A reporting tool
 
 
-## API Documentation
-
-[Api Documentation](https://store-manager-develop.herokuapp.com/api-docs)
-
-
-
 ## How To Use
 
 To clone and run this application, you'll need [Git](https://git-scm.com) and [Node.js](https://nodejs.org/en/download/) (which comes with [npm](http://npmjs.com)) installed on your computer. From your command line:


### PR DESCRIPTION
#### What does this PR do?
Remove wrong link from README.md

#### Description of Task to be completed?
Remove `API DOCUMENTATION` link from README.md

#### How should this be manually tested?
Clone the repository,
cd into ft-more-endpoints-#163451769 branch
view README.md

#### Any background context you want to provide?
The link was linking to another person's api documentation, the person's tutorial I followed to update my readme

#### What are the relevant pivotal tracker stories?
#163451769

#### Screenshots (if appropriate)
none

#### Questions: