### PR TITLE
[feat #163591464]Consume signup endpoint on the Frontend

### DIFF
--- a/UI/assets/css/style.css
+++ b/UI/assets/css/style.css
@@ -58,6 +58,19 @@
   grid-template-columns: auto auto;
   padding: 0px;
 }
+.content .auth-signup .card form .error,
+.content .auth-login .card form .error{
+  display:none;
+  width: 100%;
+  height: 30px;
+  background: #e87676;
+  color: white;
+  border-radius: 8px;
+  /* display: flex; */
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+}
 .content .auth-signup .card form .input-grid .input-div,
 .content .auth-login .card form .input-div,
 .content .auth .card form .input-div{
@@ -342,8 +355,13 @@ label{
   .auth-login input,
   .auth-email input{
     opacity: 0.8;
-    color:#000000;
-    /* background-color: red!important; */
+    color:#000;
+  }
+
+  .auth-login .btn-submit,
+  .auth-signup .btn-submit{
+    opacity: 0.8;
+    color:#FFF!important;
   }
   .content.signup{
     padding: 100px 0px;

--- a/UI/assets/js/auth.js
+++ b/UI/assets/js/auth.js
@@ -1,37 +1,34 @@
 
+const signup = (user) => {
 
-const newPost = (post) => {
-  // const setOptions = {
-  //   method: 'POST',
-  //   body: JSON.stringify(post),
-  //   header: new Headers({
-  //     'Content-Type': 'application/json',
-  //   }),
-  // };
+  const options = {
+    method: 'POST',
+    body: JSON.stringify(user),
+    headers: new Headers({
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    }),
+  };
 
-  // return fetch('https://andela-questioner-app.herokuapp.com/api/v1/meetups/upcoming')
-  //   .then(res => res.json())
-  //   .then(res => console.log(res))
-  //   .catch(error => console.log(error));
+  return fetch('http://127.0.0.1:8080/api/v1/auth/signup', options)
+    .then(res => res.json())
+    .then(res => res)
+    .catch(err => console.log(err));
 };
 
-// const post = {
-//   title: 'Pretty little fears',
-//   body: 'Now can you tell me like it is',
-//   userId: 1,
-// };
 
+const signUp = () => {
+  const password = document.querySelector('#password').value;
+  const confirmPassword = document.querySelector('#confirmPassword').value;
+  console.log(password, confirmPassword);
 
-const logger = () => {
-  // const formData = new FormData(document.querySelector('#signup'));
-  // for (const pair of formData.entries()) {
-  //   console.log(pair[0], pair[1]);
-  // }
-
-  return fetch('http://127.0.0.1:8080/api/v1/meetups/upcoming')
-    .then(res => res.json())
-    .then((posts) => {
-      console.log(posts);
-    });
-  // newPost(post);
+  if (password !== confirmPassword) {
+    return alert('passwords do not match!')
+  }
+  const formData = new FormData(document.querySelector('#signup'));
+  const user = {};
+  for (const [key, value]  of formData.entries()) {
+      user[key] = value;
+  }
+  // signup(user);
 };

--- a/UI/assets/js/formValidation.js
+++ b/UI/assets/js/formValidation.js
@@ -1,0 +1,195 @@
+/* ----------------------------
+
+	CustomValidation prototype
+
+	- Keeps track of the list of invalidity messages for this input
+	- Keeps track of what validity checks need to be performed for this input
+	- Performs the validity checks and sends feedback to the front end
+
+---------------------------- */
+
+function CustomValidation() {
+	this.invalidities = [];
+	this.validityChecks = [];
+}
+
+CustomValidation.prototype = {
+	addInvalidity: function(message) {
+		this.invalidities.push(message);
+	},
+	getInvalidities: function() {
+		return this.invalidities.join('. \n');
+	},
+	checkValidity: function(input) {
+		for ( var i = 0; i < this.validityChecks.length; i++ ) {
+
+			var isInvalid = this.validityChecks[i].isInvalid(input);
+			if (isInvalid) {
+				this.addInvalidity(this.validityChecks[i].invalidityMessage);
+			}
+
+			var requirementElement = this.validityChecks[i].element;
+			if (requirementElement) {
+				if (isInvalid) {
+					requirementElement.classList.add('invalid');
+					requirementElement.classList.remove('valid');
+				} else {
+					requirementElement.classList.remove('invalid');
+					requirementElement.classList.add('valid');
+				}
+
+			} // end if requirementElement
+		} // end for
+	}
+};
+
+
+
+/* ----------------------------
+
+	Validity Checks
+
+	The arrays of validity checks for each input
+	Comprised of three things
+		1. isInvalid() - the function to determine if the input fulfills a particular requirement
+		2. invalidityMessage - the error message to display if the field is invalid
+		3. element - The element that states the requirement
+
+---------------------------- */
+
+var usernameValidityChecks = [
+	{
+		isInvalid: function(input) {
+			return input.value.length < 3;
+		},
+		invalidityMessage: 'This input needs to be at least 3 characters',
+		element: document.querySelector('label[for="username"] .input-requirements li:nth-child(1)')
+	},
+	{
+		isInvalid: function(input) {
+			var illegalCharacters = input.value.match(/[^a-zA-Z0-9]/g);
+			return illegalCharacters ? true : false;
+		},
+		invalidityMessage: 'Only letters and numbers are allowed',
+		element: document.querySelector('label[for="username"] .input-requirements li:nth-child(2)')
+	}
+];
+
+var passwordValidityChecks = [
+	{
+		isInvalid: function(input) {
+			return input.value.length < 8 | input.value.length > 100;
+		},
+		invalidityMessage: 'This input needs to be between 8 and 100 characters',
+		element: document.querySelector('label[for="password"] .input-requirements li:nth-child(1)')
+	},
+	{
+		isInvalid: function(input) {
+			return !input.value.match(/[0-9]/g);
+		},
+		invalidityMessage: 'At least 1 number is required',
+		element: document.querySelector('label[for="password"] .input-requirements li:nth-child(2)')
+	},
+	{
+		isInvalid: function(input) {
+			return !input.value.match(/[a-z]/g);
+		},
+		invalidityMessage: 'At least 1 lowercase letter is required',
+		element: document.querySelector('label[for="password"] .input-requirements li:nth-child(3)')
+	},
+	{
+		isInvalid: function(input) {
+			return !input.value.match(/[A-Z]/g);
+		},
+		invalidityMessage: 'At least 1 uppercase letter is required',
+		element: document.querySelector('label[for="password"] .input-requirements li:nth-child(4)')
+	},
+	{
+		isInvalid: function(input) {
+			return !input.value.match(/[\!\@\#\$\%\^\&\*]/g);
+		},
+		invalidityMessage: 'You need one of the required special characters',
+		element: document.querySelector('label[for="password"] .input-requirements li:nth-child(5)')
+	}
+];
+
+var passwordRepeatValidityChecks = [
+	{
+		isInvalid: function() {
+			return passwordRepeatInput.value != passwordInput.value;
+		},
+		invalidityMessage: 'This password needs to match the first one'
+	}
+];
+
+
+
+/* ----------------------------
+
+	Check this input
+
+	Function to check this particular input
+	If input is invalid, use setCustomValidity() to pass a message to be displayed
+
+---------------------------- */
+
+function checkInput(input) {
+
+	input.CustomValidation.invalidities = [];
+	input.CustomValidation.checkValidity(input);
+
+	if ( input.CustomValidation.invalidities.length == 0 && input.value != '' ) {
+		input.setCustomValidity('');
+	} else {
+		var message = input.CustomValidation.getInvalidities();
+		input.setCustomValidity(message);
+	}
+}
+
+
+
+/* ----------------------------
+
+	Setup CustomValidation
+
+	Setup the CustomValidation prototype for each input
+	Also sets which array of validity checks to use for that input
+
+---------------------------- */
+
+var usernameInput = document.getElementById('username');
+var passwordInput = document.getElementById('password');
+var passwordRepeatInput = document.getElementById('password_repeat');
+
+usernameInput.CustomValidation = new CustomValidation();
+usernameInput.CustomValidation.validityChecks = usernameValidityChecks;
+
+passwordInput.CustomValidation = new CustomValidation();
+passwordInput.CustomValidation.validityChecks = passwordValidityChecks;
+
+passwordRepeatInput.CustomValidation = new CustomValidation();
+passwordRepeatInput.CustomValidation.validityChecks = passwordRepeatValidityChecks;
+
+
+
+
+/* ----------------------------
+
+	Event Listeners
+
+---------------------------- */
+
+var inputs = document.querySelectorAll('input:not([type="submit"])');
+var submit = document.querySelector('input[type="submit"');
+
+for (var i = 0; i < inputs.length; i++) {
+	inputs[i].addEventListener('keyup', function() {
+		checkInput(this);
+	});
+}
+
+submit.addEventListener('click', function() {
+	for (var i = 0; i < inputs.length; i++) {
+		checkInput(inputs[i]);
+	}
+});

--- a/UI/assets/js/signup.js
+++ b/UI/assets/js/signup.js
@@ -1,0 +1,45 @@
+
+const signup = (user) => {
+  const options = {
+    method: 'POST',
+    body: JSON.stringify(user),
+    headers: new Headers({
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    }),
+  };
+
+  return fetch('http://127.0.0.1:8080/api/v1/auth/signup', options)
+    .then(res => res.json())
+    .then((res) => {
+      document.querySelector('.error').style.display = 'flex';
+      document.querySelector('.error').innerHTML = res.message;
+      localStorage.setItem('token', res.data.jwToken);
+      localStorage.setItem('id', res.data.authDetail.id);
+      window.location.replace('meetups.html');
+    })
+    .catch(err => console.log(err));
+};
+
+const signUp = (event) => {
+  event.preventDefault();
+  const password = document.querySelector('#password').value;
+  const confirmPassword = document.querySelector('#confirmPassword').value;
+
+  if (password !== confirmPassword) {
+    document.querySelector('.error').style.display = 'flex';
+    document.querySelector('.error').innerHTML = 'passwords do not match!';
+    return;
+  }
+  const formData = new FormData(document.querySelector('#signup'));
+  const user = {};
+  for (const [key, value] of formData.entries()) {
+    user[key] = value;
+  }
+
+  signup(user);
+};
+
+document.querySelector('#signup').addEventListener('submit', (event) => {
+  signUp(event);
+});

--- a/UI/sign-up.html
+++ b/UI/sign-up.html
@@ -32,38 +32,38 @@
         <div class="card d-flex justify-content-center">
           <div class="w-90">
             <p class="f-32 text-center text-blue">Sign Up</p>
-            <form class="" id="signup">
+            <form class="" id="signup" method="post">
               <div class="input-grid">
                 <div class="input-div d-flex justify-content-center">
-                  <input type="text" name="firstName" id="firstName" value="" placeholder="First Name" class="w-100">
+                  <input type="text" name="firstname" id="firstName" value="" placeholder="First Name" class="w-100" required>
                 </div>
                 <div class="input-div d-flex justify-content-center">
-                  <input type="text" name="lastName" id="lastName" value="" placeholder="Last Name" class="w-100">
+                  <input type="text" name="lastname" id="lastName" value="" placeholder="Last Name" class="w-100" required>
                 </div>
                 <div class="input-div d-flex justify-content-center">
-                  <input type="text" name="otherName" id="otherName" value="" placeholder="Other Name" class="w-100">
+                  <input type="text" name="othername" id="otherName" value="" placeholder="Other Name" class="w-100">
                 </div>
                 <div class="input-div d-flex justify-content-center">
-                  <input type="text" name="username" id="username" value="" placeholder="Username" class="w-100">
+                  <input type="text" name="username" id="username" value="" placeholder="Username" class="w-100" minlength="4" required>
                 </div>
                 <div class="input-div d-flex justify-content-center">
-                  <input type="email" name="email" id="email" value="" placeholder="Email Address" class="w-100">
+                  <input type="email" name="email" id="email" value="" placeholder="Email Address" class="w-100" required>
                 </div>
                 <div class="input-div d-flex justify-content-center">
-                  <input type="tel" name="phoneNUmber" id="phoneNUmber" value="" placeholder="Phone Number" class="w-100">
+                  <input type="tel" name="phonenumber" id="phoneNUmber" value="" placeholder="Phone Number" class="w-100">
                 </div>
                 <div class="input-div d-flex justify-content-center">
-                  <input type="password" name="password" id="password" value="" placeholder="Password" class="w-100">
+                  <input type="password" name="password" id="password" value="" placeholder="Password" class="w-100" required>
                 </div>
                 <div class="input-div d-flex justify-content-center">
-                  <input type="password" name="confirmPassword" id="confirmPassword" value="" placeholder="Confirm Password" class="w-100">
+                  <input type="password" name="confirmPassword" id="confirmPassword" value="" placeholder="Confirm Password" class="w-100" required>
                 </div>
               </div>
               <div class="input-div d-flex justify-content-center">
-                <a type="button" name="button" class="btn btn-blue w-100 d-flex justify-content-center align-items-center" onclick="logger();">
-                  Sign Up
+                <input type="submit" name="button" value="Sign Up" class="btn btn-blue w-100 d-flex justify-content-center align-items-center" onick="sigUp();">
+
                   <i class="fas fa-arrow-right text-white fa-xs"></i>
-                </a>
+                <!-- </a> -->
               </div>
               <p  class="f-12 text-grey text-center link">Already have an account? Log in <a href="login.html" class="text-blue">here</a> </p>
             </form>

--- a/UI/sign-up.html
+++ b/UI/sign-up.html
@@ -59,11 +59,11 @@
                   <input type="password" name="confirmPassword" id="confirmPassword" value="" placeholder="Confirm Password" class="w-100" required>
                 </div>
               </div>
-              <div class="input-div d-flex justify-content-center">
-                <input type="submit" name="button" value="Sign Up" class="btn btn-blue w-100 d-flex justify-content-center align-items-center" onick="sigUp();">
+              <div class="error">
 
-                  <i class="fas fa-arrow-right text-white fa-xs"></i>
-                <!-- </a> -->
+              </div>
+              <div class="input-div d-flex justify-content-center">
+                <input type="submit" name="button" value="Sign Up" class="btn btn-blue btn-submit w-100 d-flex justify-content-center align-items-center">
               </div>
               <p  class="f-12 text-grey text-center link">Already have an account? Log in <a href="login.html" class="text-blue">here</a> </p>
             </form>
@@ -76,6 +76,6 @@
       <p>Made by Edidiong Udombat @ Andela Pre-felllowship Bootcamp</p>
     </footer> -->
     <script src="./assets/js/nav.js" charset="utf-8"></script>
-    <script src="./assets/js/auth.js" charset="utf-8"></script>
+    <script src="./assets/js/signup.js" charset="utf-8"></script>
   </body>
 </html>

--- a/server/controllers/v1/auth.js
+++ b/server/controllers/v1/auth.js
@@ -19,49 +19,32 @@ class AuthController {
     const userDetails = {
       firstname, lastname, othername, username, email, password: hash, phonenumber,
     };
-    pool.query(`SELECT email from users where email = '${email}'`)
-      .then((found) => {
-        if (found.rowCount === 0) {
-          createAccount(userDetails)
-            .then((results) => {
-              if (results.rowCount > 0) {
-                const returnedUserDetails = results.rows[0];
-                const { id, role } = returnedUserDetails;
-                const authDetail = { id, username, email, role };
-                const jwToken = jwt.sign(authDetail, secretHash, { expiresIn: '100hr' });
+    createAccount(userDetails)
+      .then((results) => {
+        const returnedUserDetails = results.rows[0];
+        const { id, role } = returnedUserDetails;
+        const authDetail = { id, username, email, role };
+        const jwToken = jwt.sign(authDetail, secretHash, { expiresIn: '24hr' });
 
-                return res.status(201).json({
-                  status: 201,
-                  message: 'Account created',
-                  data: {
-                    id: results.rows[0].id,
-                    fullname: `${results.rows[0].firstname} ${results.rows[0].othername} ${results.rows[0].lastname}`,
-                    username: results.rows[0].username,
-                    email: results.rows[0].email,
-                    phonenumber: results.rows[0].phonenumber,
-                    registered: results.rows[0].registered,
-                    jwToken,
-                  },
-                });
-              }
-              return res.status(500).json({
-                status: 500,
-                error: 'Could not create account',
-              });
-            })
-            .catch(error => res.status(400).json({
-              status: 400,
-              error: error.message,
-            }));
-        } else {
-          return res.status(409).json({
-            tatus: 409,
-            message: 'email is already in use, if that email belongs to you, kindly login',
-            error: true });
-        }
-      }).catch(err => (
-        res.status(500).json(err)
-      ));
+        return res.status(201).json({
+          status: 201,
+          message: 'Account created',
+          data: {
+            id: results.rows[0].id,
+            fullname: `${results.rows[0].firstname} ${results.rows[0].othername} ${results.rows[0].lastname}`,
+            username: results.rows[0].username,
+            email: results.rows[0].email,
+            phonenumber: results.rows[0].phonenumber,
+            registered: results.rows[0].registered,
+            jwToken,
+            authDetail,
+          },
+        });
+      })
+      .catch(error => res.status(400).json({
+        status: 400,
+        error: error.message,
+      }));
   }
 
   static login(req, res) {
@@ -73,18 +56,17 @@ class AuthController {
             id: user.rows[0].id, username: user.rows[0].username, email, role: user.rows[0].role,
           };
 
-          const jwToken = jwt.sign(authDetail, secretHash, { expiresIn: '100hr' });
+          const jwToken = jwt.sign(authDetail, secretHash, { expiresIn: '24hr' });
 
           return res.status(200).json({
             status: 200,
             message: 'Successfully logged in',
             jwToken,
-            username: authDetail.username,
-            email,
+            authDetail,
           });
         }
         return res.status(404).json({ status: 404, message: 'User does not exist', error: true });
-      }).catch(/* istanbul ignore next */ err => (
+      }).catch(err => (
         res.status(500).json(err)
       ));
   }

--- a/server/database/migrations/v1/create.js
+++ b/server/database/migrations/v1/create.js
@@ -15,12 +15,12 @@ const createTables = {
       firstname VARCHAR not null,
       lastname VARCHAR not null,
       othername VARCHAR,
-      username VARCHAR not null,
+      username VARCHAR UNIQUE not null,
       email VARCHAR UNIQUE not null,
       password VARCHAR not null,
       phonenumber VARCHAR,
       role VARCHAR not null,
-      registered DATE DEFAULT NOW()
+      registered TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )`,
 
   questionsTable: `CREATE TABLE IF NOT EXISTS questions(

--- a/server/database/seeds/v1/seed.js
+++ b/server/database/seeds/v1/seed.js
@@ -7,9 +7,9 @@ const seedTables = {
     VALUES ('100daysofcode', 'learing', 'uyo', to_date('${moment('2019-11-11').format('YYYY-MM-DD')}', 'YYYY MM DD')),
     ('Freecodecamp', 'DB management', 'Ikeja', to_date('${moment('2019-08-01').format('YYYY-MM-DD')}', 'YYYY MM DD'))
     `,
-  usersTable: `INSERT INTO users(firstname, lastname, username, email, password, phonenumber, role)
-        VALUES ('nedy', 'udombat', 'nedyy', 'nedyudombat@gmail.com', '${bcrypt.hashSync('Iamtheadmin', 10)}', 07018228593, 'admin'),
-        ('Jermaine', 'Umanah', 'Jermaine1', 'jm1@gmail.com', '${bcrypt.hashSync('Iamtheseededuser', 10)}', 08025137999, 'user')
+  usersTable: `INSERT INTO users(firstname, lastname, othername, username, email, password, phonenumber, role)
+        VALUES ('nedy', 'udombat', '', 'nedyy', 'nedyudombat@gmail.com', '${bcrypt.hashSync('Iamtheadmin', 10)}', 07018228593, 'admin'),
+        ('Jermaine', 'Umanah', 'emmanuel', 'Jermaine1', 'jm1@gmail.com', '${bcrypt.hashSync('Iamtheseededuser', 10)}', 08025137999, 'user')
         `,
 
   questionsTable: `INSERT INTO questions( meetup_id, user_id, title, body)

--- a/server/middlewares/AccountValidator.js
+++ b/server/middlewares/AccountValidator.js
@@ -3,7 +3,7 @@ import Validator from '../_helpers/post_validators';
 import pool from '../database/dbConfig';
 
 class AccountValidator {
-  static createAccountValidator(req, res, next) {
+  static createAccountInputValidator(req, res, next) {
     const { firstname, lastname, username, email, password } = req.body;
 
     const fields = { firstname, lastname, username, email, password };
@@ -21,6 +21,25 @@ class AccountValidator {
       });
     }
     return next();
+  }
+
+  static createAccountDuplicateValidator(req, res, next) {
+    const { email, username } = req.body;
+    pool.query(`SELECT email from users where email = '${email}'`)
+      .then((foundEmail) => {
+        pool.query(`SELECT username from users where username = '${username}'`)
+          .then((foundUsername) => {
+            if (foundEmail.rowCount === 0 && foundUsername.rowCount === 0) {
+              return next();
+            }
+            res.status(409).json({
+              status: 409,
+              message: 'Credentials already in use',
+              error: true });
+          });
+      }).catch(err => (
+        res.status(500).json(err)
+      ));
   }
 
   static loginAccountValidator(req, res, next) {

--- a/server/routes/v1/index.js
+++ b/server/routes/v1/index.js
@@ -44,7 +44,8 @@ const {
   getAllUpvoteForQuestion, getAllDownvoteForQuestion,
 } = VoteController;
 
-const { rsvpMeetup, getAllRsvps,
+const {
+  rsvpMeetup, getAllRsvps,
   getAllRsvpsForMeetup, getAllRsvpsByUser,
 } = RsvpController;
 
@@ -54,9 +55,11 @@ const { isAdmin } = VerifyAdmin;
 const { statusValidator } = MeetupValidator;
 const { createQuestionValidator } = CreateQuestionValidator;
 const { createMeetupValidator } = CreateMeetupValidator;
-const { createAccountValidator, loginAccountValidator } = AccountValidator;
+const {
+  createAccountInputValidator, loginAccountValidator,
+  createAccountDuplicateValidator,
+} = AccountValidator;
 const { verifyToken } = VerifyToken;
-
 const { jwtDecode } = JwtDecode;
 
 
@@ -78,7 +81,7 @@ router.delete('/meetups/:meetupId', verifyToken, isAdmin, idValidator, deleteSin
 router.delete('/meetups', verifyToken, isAdmin, deleteAllMeetups);//
 
 // Authenticaton endpoints
-router.post('/auth/signup', createAccountValidator, createAccount);//
+router.post('/auth/signup', createAccountInputValidator, createAccountDuplicateValidator, createAccount);//
 router.post('/auth/login', loginAccountValidator, login);//
 
 router.get('/auth/logout', logout);

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,7 @@ const port = process.env.PORT || 8080;
 
 app.use(cors());
 app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.urlencoded({ extended: true }));
 
 app.get('/', (req, res) => {
   res.json({ message: 'Hi there! Welcome to our Questioner api! Visit /api/v1 for the Version 1 of our api' });

--- a/server/test/a_auth-test.js
+++ b/server/test/a_auth-test.js
@@ -38,7 +38,7 @@ describe('Questioner Server', () => {
         .send(validUserAccount)
         .end((err, res) => {
           expect(res.status).to.equal(409);
-          expect(res.body.message).to.eql('email is already in use, if that email belongs to you, kindly login');
+          expect(res.body.message).to.eql('Credentials already in use');
           done();
         });
     });


### PR DESCRIPTION
#### What does this PR do?
* Consume signup endpoint on the Frontend
* Add validation for duplicate username
* Change registered column in users table to use timestamp
* Move validation from auth controller to Account validation middleware

#### Description of Task to be completed?
* Consume `(POST) http://127.0.0.1:8080/api/v1/auth/signup` endpoint
* add username duplicate validatioon to account validation middleware
* Change registered column in users table to use timestamp
* Move duplicate email validation from auth controller to Account validation middleware

rewrite test for duplicate credentials to fir return statement

#### How should this be manually tested?
Clone the repository,
cd into ft-more-endpoints-#163451769 branch
Run `npm install`
Run `npm run query`
Run `npm run start:dev`
go to the `signup.html`
fill in your details and click submit

#### Any background context you want to provide?
* Individual input field validation not fully implemented
* more test  to be written for authentication

#### What are the relevant pivotal tracker stories?
#163591464

#### Screenshots (if appropriate)
none

#### Questions: