### PR TITLE
[feat #163745531]Consume login Endpoint on the Front-end

### DIFF
--- a/UI/assets/js/login.js
+++ b/UI/assets/js/login.js
@@ -1,0 +1,50 @@
+
+const login = (user) => {
+  const options = {
+    method: 'POST',
+    body: JSON.stringify(user),
+    headers: new Headers({
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    }),
+  };
+
+  fetch('http://127.0.0.1:8080/api/v1/auth/logout')
+    .then(response => response.json())
+    .then((response) => {
+      return fetch('http://127.0.0.1:8080/api/v1/auth/login', options)
+        .then(res => res.json())
+        .then((res) => {
+          document.querySelector('.error').style.display = 'flex';
+          document.querySelector('.error').innerHTML = res.message;
+          localStorage.setItem('token', res.jwToken);
+          localStorage.setItem('id', res.authDetail.id);
+          if (res.authDetail.role === 'admin') {
+            setTimeout(() => {
+              window.location.assign('admin.html');
+            }, 500);
+          } else {
+            setTimeout(() => {
+              window.location.assign('user-profile.html');
+            }, 500);
+          }
+        })
+        .catch(err => console.log(err));
+    })
+    .catch(err => console.log(err));
+};
+
+const loginEvent = (event) => {
+  event.preventDefault();
+  const formData = new FormData(document.querySelector('#login'));
+  const user = {};
+  for (const [key, value] of formData.entries()) {
+    user[key] = value;
+  }
+
+  login(user);
+};
+
+document.querySelector('#login').addEventListener('submit', (event) => {
+  loginEvent(event);
+});

--- a/UI/assets/js/signup.js
+++ b/UI/assets/js/signup.js
@@ -16,7 +16,9 @@ const signup = (user) => {
       document.querySelector('.error').innerHTML = res.message;
       localStorage.setItem('token', res.data.jwToken);
       localStorage.setItem('id', res.data.authDetail.id);
-      window.location.replace('meetups.html');
+      setTimeout(() => {
+        window.location.assign('meetups.html');
+      }, 2000);
     })
     .catch(err => console.log(err));
 };

--- a/UI/login.html
+++ b/UI/login.html
@@ -32,18 +32,18 @@
         <div class="card d-flex justify-content-center w-100">
           <div class="w-100">
             <p class="f-32 text-center text-blue">Login</p>
-            <form class="">
+            <form class="" id="login" method="post">
               <div class="input-div d-flex justify-content-center">
-                <input type="text" name="username" id="username" value="" placeholder="Username" class="w-100">
+                <input type="email" name="email" id="email" value="" placeholder="Email" class="w-100" required>
               </div>
               <div class="input-div d-flex justify-content-center">
-                <input type="password" name="password" id="password" value="" placeholder="Password" class="w-100">
+                <input type="password" name="password" id="password" value="" placeholder="Password" class="w-100" required>
+              </div>
+              <div class="error">
+
               </div>
               <div class="input-div d-flex justify-content-center">
-                <a type="button" name="button" class="btn btn-blue w-100 d-flex justify-content-center align-items-center" href="user-profile.html">
-                  Login
-                  <i class="fas fa-arrow-right text-white fa-xs"></i>
-                </a>
+                <input type="submit" name="button" value="Log In" class="btn btn-blue btn-submit w-100 d-flex justify-content-center align-items-center">
               </div>
               <p  class="f-12 text-grey text-center link mt-2">Don't have an account? Sign up <a href="sign-up.html" class="text-blue">here</a> </p>
               <p  class="f-12 text-grey text-center link">Forgot Password? <a href="forgot-password.html" class="text-blue">Go here</a> </p>
@@ -53,5 +53,6 @@
       </div>
     </div>
     <script src="./assets/js/nav.js" charset="utf-8"></script>
+    <script src="./assets/js/login.js" charset="utf-8"></script>
   </body>
 </html>

--- a/server/controllers/v1/auth.js
+++ b/server/controllers/v1/auth.js
@@ -24,7 +24,7 @@ class AuthController {
         const returnedUserDetails = results.rows[0];
         const { id, role } = returnedUserDetails;
         const authDetail = { id, username, email, role };
-        const jwToken = jwt.sign(authDetail, secretHash, { expiresIn: '24hr' });
+        const jwToken = jwt.sign(authDetail, secretHash, { expiresIn: '2hr' });
 
         return res.status(201).json({
           status: 201,
@@ -56,7 +56,7 @@ class AuthController {
             id: user.rows[0].id, username: user.rows[0].username, email, role: user.rows[0].role,
           };
 
-          const jwToken = jwt.sign(authDetail, secretHash, { expiresIn: '24hr' });
+          const jwToken = jwt.sign(authDetail, secretHash, { expiresIn: '2hr' });
 
           return res.status(200).json({
             status: 200,

--- a/server/middlewares/VerifyToken.js
+++ b/server/middlewares/VerifyToken.js
@@ -16,6 +16,9 @@ class VerifyToken {
       });
     }
     jwt.verify(jwToken, secretHash, (err, authData) => {
+      if (err) {
+        return res.status(400).json(err);
+      }
       req.authData = authData;
       return next();
     });

--- a/server/routes/v1/index.js
+++ b/server/routes/v1/index.js
@@ -84,7 +84,7 @@ router.delete('/meetups', verifyToken, isAdmin, deleteAllMeetups);//
 router.post('/auth/signup', createAccountInputValidator, createAccountDuplicateValidator, createAccount);//
 router.post('/auth/login', loginAccountValidator, login);//
 
-router.get('/auth/logout', logout);
+router.post('/auth/logout', logout);
 
 // User endpoints
 router.get('/users', verifyToken, isAdmin, getAllUsers);

--- a/server/test/a_auth-test.js
+++ b/server/test/a_auth-test.js
@@ -111,7 +111,7 @@ describe('Questioner Server', () => {
 
     it('/api/v1/auth/logout should respond with status code 200 and log user out', (done) => {
       chai.request(app)
-        .get('/api/v1/auth/logout')
+        .post('/api/v1/auth/logout')
         .set('Accept', 'application/json')
         .send(validAdminAccount)
         .end((err, res) => {


### PR DESCRIPTION
#### What does this PR do?
* Consume login endpoint on the Frontend

#### Description of Task to be completed?
* Consume `(POST) http://127.0.0.1:8080/api/v1/auth/login` endpoint

rewrite test for duplicate credentials to fit return statement

#### How should this be manually tested?
Clone the repository,
cd into ft-more-endpoints-#163451769 branch
Run `npm install`
Run `npm run query`
Run `npm run start:dev`
go to the `login.html`
fill in your details and click submit

#### Any background context you want to provide?
* Individual input field validation not fully implemented
* more test  to be written for authentication

#### What are the relevant pivotal tracker stories?
#163745531

#### Screenshots (if appropriate)
none

#### Questions: