### PR TITLE
[feat #163761605]Consume  Endpoint from the Frontend

### DIFF
--- a/UI/assets/js/logout.js
+++ b/UI/assets/js/logout.js
@@ -1,0 +1,14 @@
+const logout = () => {
+  fetch('http://127.0.0.1:8080/api/v1/auth/logout')
+    .then(response => response.json())
+    .then(() => {
+      localStorage.removeItem('token');
+      localStorage.removeItem('id');
+      window.location.replace('login.html');
+    })
+    .catch(err => console.log(err));
+};
+
+document.querySelector('#logout').addEventListener('submit', () => {
+  logout();
+});


### PR DESCRIPTION
#### What does this PR do?
* Consume logout endpoint on the Frontend

#### Description of Task to be completed?
* Consume `(POST) http://127.0.0.1:8080/api/v1/auth/logout` endpoint

rewrite test for duplicate credentials to fit return statement

#### How should this be manually tested?
Clone the repository,
cd into ft-more-endpoints-#163451769 branch
Run `npm install`
Run `npm run query`
Run `npm run start:dev`
clink on a logout  button

#### Any background context you want to provide?
none

#### What are the relevant pivotal tracker stories?
#163761605

#### Screenshots (if appropriate)
none

#### Questions: